### PR TITLE
increase email, name data in auth context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,11 @@ function App() {
 						if (!auth.token) {
 							const response = role === 'user' ? await getUserData() : await getOwnerData();
 							if (response.status === 200) {
-								const { id, token } = response.data;
+								const { id, token, email } = response.data;
 								if (response.data.hasOwnProperty('avatar')) {
 									setAuth({
+										name: response.data.nickname,
+										email,
 										token,
 										avatar: response.data.avatar,
 										userId: id,
@@ -35,6 +37,8 @@ function App() {
 									navigateToRoleDefaultPage(pathname, 'user', id);
 								} else {
 									setAuth({
+										name: response.data.storeName,
+										email,
 										token,
 										avatar: '',
 										userId: id,
@@ -68,6 +72,8 @@ function App() {
 	function handleLogout() {
 		localStorage.removeItem('isport');
 		setAuth({
+			name: '',
+			email: '',
 			token: '',
 			role: '',
 			userId: 0,

--- a/src/contexts/authContext.tsx
+++ b/src/contexts/authContext.tsx
@@ -2,6 +2,8 @@ import { ReactNode, SetStateAction, createContext, useContext, useState, Dispatc
 
 type AuthType = {
 	token: string;
+	email: string;
+	name: string;
 	role: string;
 	userId: 0;
 	avatar: string;
@@ -14,6 +16,8 @@ const AuthContext = createContext<AuthContextProps | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
 	const [auth, setAuth] = useState<AuthType>({
+		email: '',
+		name: '',
 		token: '',
 		role: '',
 		userId: 0,

--- a/src/pages/Auth/Login/index.tsx
+++ b/src/pages/Auth/Login/index.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
 			if (response.status === 200) {
 				const { token, avatar, role, userId } = response.data;
 				localStorage.setItem('isport', JSON.stringify({ token, role }));
-				setAuth({ token, role, userId, avatar, isAuthenticated: true });
+				setAuth({ token, role, userId, avatar, isAuthenticated: true, email: '', name: '' });
 				navigate('/find');
 			}
 		} catch (error) {

--- a/src/pages/Auth/Signup/StepOne/index.tsx
+++ b/src/pages/Auth/Signup/StepOne/index.tsx
@@ -29,7 +29,7 @@ export default function SignupStepOnePage() {
 			if (response.status === 200) {
 				const { token, userId, role } = response.data;
 				localStorage.setItem('isport', JSON.stringify({ token, role }));
-				setAuth({ token, role, userId, isAuthenticated: true, avatar: '' });
+				setAuth({ token, role, userId, isAuthenticated: true, avatar: '', name: '', email: '' });
 				navigate(`/signup/${userId}`);
 			}
 		} catch (error) {

--- a/src/pages/Auth/Store/Login/index.tsx
+++ b/src/pages/Auth/Store/Login/index.tsx
@@ -26,7 +26,7 @@ export default function StoreLoginPage() {
 			if (response.status === 200) {
 				const { token, userId, role } = response.data;
 				localStorage.setItem('isport', JSON.stringify({ token, role }));
-				setAuth({ token, userId, role, isAuthenticated: true, avatar: '' });
+				setAuth({ token, userId, role, isAuthenticated: true, avatar: '', email: '', name: '' });
 				navigate(`/store/${userId}/find`);
 			}
 		} catch (error) {

--- a/src/pages/Auth/Store/Signup/index.tsx
+++ b/src/pages/Auth/Store/Signup/index.tsx
@@ -32,7 +32,7 @@ export default function StoreSignupPage() {
 			if (response.status === 200) {
 				const { userId, token } = response.data;
 				localStorage.setItem('isport', JSON.stringify({ token, role: 'owner' }));
-				setAuth({ token, userId, avatar: '', isAuthenticated: true, role: 'owner' });
+				setAuth({ token, userId, avatar: '', isAuthenticated: true, role: 'owner', email: '', name: '' });
 				navigate(`/store/${userId}/find`);
 			}
 		} catch (error) {


### PR DESCRIPTION
更新了 email 跟 name 可以在使用 `useAuth` 後拿到

不過要留意的地方是，一開始登入後的資料內因為沒有 email, name 的資料，到帳戶的頁面仍然得呼叫一次 getOwner 或 getUser 的 data 才有辦法得到值，所以也可以不用這個 authContext 直接在該頁面去做到 get data。

未來如果有其他頁面要用到這些使用者資料，可以直接拿取使用。例如金流頁面中，如果要顯示使用者個人資料，就可以取用