### PR TITLE
feature/fix-header-link

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -27,7 +27,7 @@ export default function Header({
 
 				<div className={styles.header__linkWrap}>
 					{role && (
-						<Link to='/find'>
+						<Link to={role === 'user' ? '/find' : `/store/${currentUserId}/find`}>
 							<Button className={styles.header__linkWrap__link}>找場館</Button>
 						</Link>
 					)}


### PR DESCRIPTION
發現再點擊 logo 旁邊的「找場館」會發生錯誤，主要是因為 `Link` 錯誤
以修正為：
使用者為 `user` 則到 `/find`
使用者為 `owner` 則到 `/store/${currentUserId}/find`
等網址