### PR TITLE
feature/change-storeId-in-localStorage

### DIFF
--- a/src/pages/UserInfo/MyPlan/PlanItem/index.tsx
+++ b/src/pages/UserInfo/MyPlan/PlanItem/index.tsx
@@ -14,7 +14,7 @@ export default function PlanItem({ id, storeName, plans }: PlanItemProps) {
 	return (
 		isPlanMissing && (
 			<li className={styles.item}>
-				<Link to={`/find/${id}`}>
+				<Link to={`/find/${id}`} onClick={() => localStorage.setItem('oneStoreId', id.toString())}>
 					<header className={`${styles.item__header} ${styles.item__row}`}>
 						<h3>{storeName}</h3>
 					</header>

--- a/src/pages/UserInfo/MyPlan/index.tsx
+++ b/src/pages/UserInfo/MyPlan/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import PlanItem from './PlanItem';
-import styles from './styles.module.scss';
 import { getUserPlans } from '../../../api/user';
-import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import PlanItem from './PlanItem';
+import Loading from '../../../components/Loading';
+import styles from './styles.module.scss';
 
 export type UserPlanType = {
 	id: number;
@@ -45,7 +45,7 @@ export default function MyPlanPage() {
 	return (
 		<ul className={styles.myPlan}>
 			{isFetching ? (
-				<AiOutlineLoading3Quarters className={styles.loading} />
+				<Loading />
 			) : plans.length ? (
 				plans.map((plan) => (
 					<PlanItem


### PR DESCRIPTION
當使用者每次點擊我的帳戶後的商家項目，都會跳轉到該商家頁面。
主要是經由 localStorage 的 oneStoreId